### PR TITLE
Small tweak to force a rebuild and version bump

### DIFF
--- a/dist/types/Requests.d.ts
+++ b/dist/types/Requests.d.ts
@@ -15,6 +15,7 @@ export interface BookingDetails {
     bookingTitle?: string;
     description?: string;
     timeSpan: TimeDetails;
+    desiredCapacity?: number;
     spaces: SpaceDetails[];
     resources: ResourceDetails[];
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hively-request-sdk",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hively-request-sdk",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "ISC",
       "devDependencies": {
         "typescript": "^5.6.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hively-request-sdk",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/types/Requests.ts
+++ b/src/types/Requests.ts
@@ -18,6 +18,7 @@ export interface BookingDetails {
   bookingTitle?: string;
   description?: string;
   timeSpan: TimeDetails;
+  desiredCapacity?: number;
   spaces: SpaceDetails[];
   resources: ResourceDetails[];
 }


### PR DESCRIPTION
Previous package scripts were not properly pubishing the build dist folder before tagging the release.  Should now be fixed and just need a concrete change to the deployables in order to be able to force an updated version.  